### PR TITLE
Fixed constant text file ("proyectar")

### DIFF
--- a/source/meta/customizations/textos-constantes-v1.ptx
+++ b/source/meta/customizations/textos-constantes-v1.ptx
@@ -37,6 +37,6 @@
   <custom name="resumen-leccion-titulo-extraProfe"><nbsp/>(para los estudiantes)</custom>
   <custom name="resumen-leccion-titulo-extraProfe-corto"><nbsp/>(estudiantes)</custom>
   <custom name="centros-ubicacion-act-intro-titlulo">Ubicación de actividad de introducción</custom>
-  <custom name="texto-link-pdf-cool-down">Descargar pdf para imprimir o projectar</custom>
+  <custom name="texto-link-pdf-cool-down">Descargar pdf para imprimir o proyectar</custom>
 
 </pi:customizations>


### PR DESCRIPTION
Había un texto constante con un error de ortografía: `projectar` debería ser `proyectar`